### PR TITLE
operators/defer - fix URLs to javadoc

### DIFF
--- a/documentation/operators/defer.html
+++ b/documentation/operators/defer.html
@@ -53,7 +53,7 @@ id: defer
       <code>defer</code> does not by default operate on a particular <a href="../scheduler.html">Scheduler</a>.
      </p>
      <ul>
-      <li>Javadoc: <a href="http://reactive.io/RxJava/javadoc/rx/Observable.html#defer(rx.functions.Func0)"><code>defer()</code></a></li>
+      <li>Javadoc: <a href="http://reactivex.io/RxJava/javadoc/rx/Observable.html#defer(rx.functions.Func0)"><code>defer()</code></a></li>
      </ul></figcaption>
     </figure>
     <figure class="variant">
@@ -85,7 +85,7 @@ id: defer
       <code>defer</code> does not by default operate on a particular <a href="../scheduler.html">Scheduler</a>.
      </p>
      <ul>
-      <li>Javadoc: <a href="http://reactive.io/RxJava/javadoc/rx/Observable.html#defer(rx.functions.Func0)"><code>defer()</code></a></li>
+      <li>Javadoc: <a href="http://reactivex.io/RxJava/javadoc/rx/Observable.html#defer(rx.functions.Func0)"><code>defer()</code></a></li>
      </ul></figcaption>
     </figure>
     <figure class="variant">


### PR DESCRIPTION
Fixed typos in links to javadoc for defer operator.

BTW can't "{{site.url}}" be used instead of "reactivex.io" in URLs?
